### PR TITLE
Use an absolute path if workplace has multi root

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,9 +7,10 @@ const ncp = require('copy-paste');
 export function activate(context: vscode.ExtensionContext) {
 	// Following are just data provider samples
 	const sassFileRoute = vscode.workspace.getConfiguration('sassVariablesHelper').route[0] === '/' ? vscode.workspace.getConfiguration('sassVariablesHelper').route : `/${vscode.workspace.getConfiguration('sassVariablesHelper').route}`
-	let rootPath = '';
-	if (sassFileRoute) {
-		rootPath = vscode.workspace.rootPath + sassFileRoute;
+	let rootPath = sassFileRoute;
+
+	if (sassFileRoute && vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length < 2) {
+		rootPath = vscode.workspace.workspaceFolders[0].uri.fsPath + sassFileRoute;
 	}
 	const sassVariablesProvider = new colorProvider(rootPath);
 


### PR DESCRIPTION
Use workspace.workspaceFolders instead of workspace.rootPath (who is deprecated), and use an absolute path if there is more than one folder in the workspace